### PR TITLE
switch to use SCons logic to handle versioned shared libraries and sonames

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -162,8 +162,6 @@ def create_base_env(vars):
     if "gcc" in env["TOOLS"]:
         env.MergeFlags("-pthread")
         env.AppendUnique(CXXFLAGS=["-std=c++03"])
-    if sys.platform.startswith("linux"):
-        env.Append(SHLINKFLAGS="-Wl,-soname,${TARGET.file}.${libversion.split('.')[0]}")
     return env
 
 def display_help(env,vars):

--- a/site_scons/site_tools/installer.py
+++ b/site_scons/site_tools/installer.py
@@ -53,27 +53,11 @@ def InstallConfig(env,src,dest=None):
     env.Clean("install",env.subst("$DESTDIR$sysconfdir/$package_name"))
     return inst
 
-def InstallStaticLibrary(env,src):
-    return Install(env,src,"$libdir")
-
-def InstallSharedLibrary(env,src):
-    if sys.platform.startswith("linux"):
-        name=os.path.split(str(src[0]))[1]
-        version=env["libversion"]
-        inst=Install(env,src,"$libdir",instname=name+"."+version,mode=0755)
-        libpath=os.path.split(inst[0].path)[0]
-        for s in [name+"."+version.split(".")[0],name]:
-            inst+=env.Command(os.path.join(libpath,s),inst[0],"ln -s ${SOURCE.file} ${TARGET.file}",chdir=1)
-            env.AddPostAction(inst[-1],Chmod("$TARGET",0755))
-    else:
-        inst=Install(env,src,"$libdir",mode=0755)
-    return inst
-
 def InstallLibrary(env,src):
     if env.IsLibraryShared():
-        return InstallSharedLibrary(env,src)
+        return env.InstallVersionedLib('$libdir',src)
     else:
-        return InstallStaticLibrary(env,src)
+        return env.Install('$libdir',src)
 
 def InstallHeader(env,src):
     return Install(env,src,"$includedir")

--- a/src/audio/SConscript
+++ b/src/audio/SConscript
@@ -18,7 +18,7 @@ import os
 
 Import("env","libRHVoice_core")
 local_env=env.Clone()
-local_env["libversion"]="0.0.0"
+local_env["SHLIBVERSION"]="0.0.0"
 local_env["liblevel"]=1
 src=["audio.cpp"]
 if "libao" in local_env["audio_libs"]:

--- a/src/core/SConscript
+++ b/src/core/SConscript
@@ -19,7 +19,7 @@ import os.path
 
 Import("env","libsonic","libhts_engine","libmage")
 local_env=env.Clone()
-local_env["libversion"]="0.0.0"
+local_env["SHLIBVERSION"]="0.0.0"
 local_env["liblevel"]=1
 local_env.Append(CPPDEFINES=("DATA_PATH",r'\"data\"' if local_env["PLATFORM"]=="win32" else local_env.subst(r'\"$datadir/$package_name\"')))
 local_env.Append(CPPDEFINES=("CONFIG_PATH",r'\"config\"' if local_env["PLATFORM"]=="win32" else local_env.subst(r'\"$sysconfdir/$package_name\"')))

--- a/src/lib/SConscript
+++ b/src/lib/SConscript
@@ -17,7 +17,7 @@ import os
 import os.path
 Import(["env","libRHVoice_core"])
 local_env=env.Clone()
-local_env["libversion"]="2.0.0"
+local_env["SHLIBVERSION"]="2.0.0"
 local_env["liblevel"]=2
 local_env.Prepend(LIBS=libRHVoice_core)
 src=["lib.cpp"]


### PR DESCRIPTION
This works with latest scons and on my centos 7 linux system.
I do get this when I run though.

LD_LIBRARY_PATH=$PWD/build/linux/core:$PWD/build/linux/lib python src/nvda-synthDriver/RHVoice.py -o say.wav "say something"
RHVoice 0.5.1
RHVoice_tts_engine_struct: No language resources are available
Traceback (most recent call last):
  File "src/nvda-synthDriver/RHVoice.py", line 285, in <module>
    main()
  File "src/nvda-synthDriver/RHVoice.py", line 235, in main
    raise RuntimeError("RHVoice: engine initialization error")
RuntimeError: RHVoice: engine initialization error

I think this is unrelated to the library versioning issues you mentioned in the mailing list.
